### PR TITLE
Add privacy to leaderboard addresses

### DIFF
--- a/src/components/features/leaderboard/index.tsx
+++ b/src/components/features/leaderboard/index.tsx
@@ -47,6 +47,13 @@ export function LeaderboardDashboard() {
     )
   }
 
+  const shortenAddress = (address: string): string => {
+    if (!address) return ""
+    // Take 0x + first 4 (after prefix) and last 4 characters.
+      return address.slice(0, 6) + '...' + address.slice(-4)
+    
+  }
+
   return (
     <div className="flex flex-col min-h-screen bg-background text-foreground">
       <Header />
@@ -386,7 +393,7 @@ export function LeaderboardDashboard() {
                           <TableCell>
                             <div className="flex items-center justify-between">
                               <div className="flex items-center gap-2">
-                                {row.trader}
+                                {shortenAddress(row.trader)}
                                 {row.prize && (
                                   <Badge variant="secondary" className="bg-[var(--color-long-dark)]/30 text-[var(--color-long)] border-[var(--color-long)]/50">
                                     ${row.prize.toLocaleString()}


### PR DESCRIPTION
The motivation is to add a layer of privacy to the leaderboard. Not everyone needs to know the full addresses of traders. Most protocols use some sort of obfuscation and only show the first few digits of addresses.

<img width="1320" alt="Capture d’écran 2025-02-19 à 08 44 19" src="https://github.com/user-attachments/assets/963ac5f6-7810-422e-984d-c8ccb407fed0" />


